### PR TITLE
Nuclear tag

### DIFF
--- a/src/app/components/transactions/transaction-detail/transaction-detail.component.html
+++ b/src/app/components/transactions/transaction-detail/transaction-detail.component.html
@@ -762,7 +762,7 @@
         (click)="toggleNuclear()"
         class="btn btn-danger btn-lg"
       >
-        <i class="fa-sharp fa-solid fa-radiation"></i>
+        <i class="fa-solid fa-radiation"></i>
       </button>
 
       <button

--- a/src/app/components/transactions/transaction-detail/transaction-detail.component.html
+++ b/src/app/components/transactions/transaction-detail/transaction-detail.component.html
@@ -751,6 +751,21 @@
       </div>
 
       <button
+        *ngIf="!transaction?.nuclear && !transaction?.complete"
+        (click)="toggleNuclear()"
+        class="btn btn-outline-warning btn-lg"
+      >
+        <i class="fa-solid fa-radiation"></i>
+      </button>
+      <button
+        *ngIf="transaction?.nuclear && !transaction?.complete"
+        (click)="toggleNuclear()"
+        class="btn btn-danger btn-lg"
+      >
+        <i class="fa-solid fa-radiation"></i>
+      </button>
+
+      <button
         *ngIf="!transaction?.urgent && !transaction?.complete"
         (click)="toggleUrgent()"
         class="btn btn-outline-warning btn-lg"

--- a/src/app/components/transactions/transaction-detail/transaction-detail.component.html
+++ b/src/app/components/transactions/transaction-detail/transaction-detail.component.html
@@ -762,7 +762,7 @@
         (click)="toggleNuclear()"
         class="btn btn-danger btn-lg"
       >
-        <i class="fa-solid fa-radiation"></i>
+        <i class="fa-sharp fa-solid fa-radiation"></i>
       </button>
 
       <button

--- a/src/app/components/transactions/transaction-detail/transaction-detail.component.html
+++ b/src/app/components/transactions/transaction-detail/transaction-detail.component.html
@@ -755,14 +755,14 @@
         (click)="toggleNuclear()"
         class="btn btn-outline-warning btn-lg"
       >
-        <i class="fa-solid fa-radiation"></i>
+        <i class="fas fa-radiation"></i>
       </button>
       <button
         *ngIf="transaction?.nuclear && !transaction?.complete"
         (click)="toggleNuclear()"
         class="btn btn-danger btn-lg"
       >
-        <i class="fa-solid fa-radiation"></i>
+        <i class="fas fa-radiation"></i>
       </button>
 
       <button

--- a/src/app/components/transactions/transaction-detail/transaction-detail.component.ts
+++ b/src/app/components/transactions/transaction-detail/transaction-detail.component.ts
@@ -260,6 +260,10 @@ export class TransactionDetailComponent implements OnInit {
     this.transaction.urgent = !this.transaction.urgent;
     this.updateTransaction();
   }
+  toggleNuclear(): void {
+    this.transaction.nuclear = !this.transaction.nuclear;
+    this.updateTransaction();
+  }
 
   /**
    * Sets order request transaction will be waiting on to arrive

--- a/src/app/components/transactions/transactions.component.html
+++ b/src/app/components/transactions/transactions.component.html
@@ -136,7 +136,7 @@
                   class="fa fa-wrench"></i></span>
               <span *ngIf="transaction?.waiting_email" class="badge badge-danger"><i class="fa fa-envelope"></i> </span>
               <span *ngIf="transaction?.urgent" class="badge badge-danger"><i class="fas fa-exclamation"></i></span>
-              <span *ngIf="transaction?.nuclear" class="badge badge-danger"><i class="fa-solid fa-radiation"></i></span>
+              <span *ngIf="transaction?.nuclear" class="badge badge-danger"><i class="fa-sharp fa-solid fa-radiation"></i></span>
     
             </th>
             <td *ngIf="!(currentTab === 'retrospec' && !transaction.reserved)">{{transaction.customer.first_name}} {{transaction.customer.last_name}}</td>

--- a/src/app/components/transactions/transactions.component.html
+++ b/src/app/components/transactions/transactions.component.html
@@ -136,7 +136,7 @@
                   class="fa fa-wrench"></i></span>
               <span *ngIf="transaction?.waiting_email" class="badge badge-danger"><i class="fa fa-envelope"></i> </span>
               <span *ngIf="transaction?.urgent" class="badge badge-danger"><i class="fas fa-exclamation"></i></span>
-              <span *ngIf="transaction?.nuclear" class="badge badge-danger"><i class="fa-solid fa-radiation"></i></span>
+              <span *ngIf="transaction?.nuclear" class="badge badge-danger"><i class="fas fa-radiation"></i></span>
     
             </th>
             <td *ngIf="!(currentTab === 'retrospec' && !transaction.reserved)">{{transaction.customer.first_name}} {{transaction.customer.last_name}}</td>

--- a/src/app/components/transactions/transactions.component.html
+++ b/src/app/components/transactions/transactions.component.html
@@ -136,6 +136,7 @@
                   class="fa fa-wrench"></i></span>
               <span *ngIf="transaction?.waiting_email" class="badge badge-danger"><i class="fa fa-envelope"></i> </span>
               <span *ngIf="transaction?.urgent" class="badge badge-danger"><i class="fas fa-exclamation"></i></span>
+              <span *ngIf="transaction?.nuclear" class="badge badge-danger"><i class="fa-solid fa-radiation"></i></span>
     
             </th>
             <td *ngIf="!(currentTab === 'retrospec' && !transaction.reserved)">{{transaction.customer.first_name}} {{transaction.customer.last_name}}</td>

--- a/src/app/components/transactions/transactions.component.html
+++ b/src/app/components/transactions/transactions.component.html
@@ -136,7 +136,7 @@
                   class="fa fa-wrench"></i></span>
               <span *ngIf="transaction?.waiting_email" class="badge badge-danger"><i class="fa fa-envelope"></i> </span>
               <span *ngIf="transaction?.urgent" class="badge badge-danger"><i class="fas fa-exclamation"></i></span>
-              <span *ngIf="transaction?.nuclear" class="badge badge-danger"><i class="fa-sharp fa-solid fa-radiation"></i></span>
+              <span *ngIf="transaction?.nuclear" class="badge badge-danger"><i class="fa-solid fa-radiation"></i></span>
     
             </th>
             <td *ngIf="!(currentTab === 'retrospec' && !transaction.reserved)">{{transaction.customer.first_name}} {{transaction.customer.last_name}}</td>

--- a/src/app/models/transaction.ts
+++ b/src/app/models/transaction.ts
@@ -14,6 +14,7 @@ export class Transaction {
   reserved: boolean;
   is_paid: boolean;
   urgent: boolean;
+  nuclear: boolean;
   waiting_email: boolean;
   employee: boolean;
   total_cost: number;

--- a/src/index.html
+++ b/src/index.html
@@ -20,6 +20,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="assets/img/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="96x96" href="assets/img/favicon-96x96.png">
   <link rel="icon" type="image/png" sizes="16x16" href="assets/img/favicon-16x16.png">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
   <link rel="manifest" href="assets/img/manifest.json">
   <meta name="msapplication-TileColor" content="#ffffff">
   <meta name="msapplication-TileImage" content="/ms-icon-144x144.png">

--- a/src/index.html
+++ b/src/index.html
@@ -20,7 +20,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="assets/img/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="96x96" href="assets/img/favicon-96x96.png">
   <link rel="icon" type="image/png" sizes="16x16" href="assets/img/favicon-16x16.png">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
   <link rel="manifest" href="assets/img/manifest.json">
   <meta name="msapplication-TileColor" content="#ffffff">
   <meta name="msapplication-TileImage" content="/ms-icon-144x144.png">


### PR DESCRIPTION
new features:
- nuclear tag: similar to priority button, marks bike as MOS only

changes
- they do not contribute to incomplete bike count
- they do not show up in waiting on pickup tab when completed
- they do not contribute to waiting on pickup count
- beer bike tab shows all beer bikes from oldest to newest

bug fixes:
- beer bikes no longer disappear when completed
- they stay in beer bike tab
